### PR TITLE
update argon to 1.4.6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 
 add_subdirectory($ENV{GEODE_SDK} ${CMAKE_CURRENT_BINARY_DIR}/geode)
 
-CPMAddPackage("gh:GlobedGD/argon@1.4.4")
+CPMAddPackage("gh:GlobedGD/argon@1.4.6")
 
 CPMAddPackage("gh:tplgy/cppcodec#8019b8b")
 


### PR DESCRIPTION
Older versions of argon had bugs that can cause crashes or auth failures, mostly prominent on macOS but present on other platforms too